### PR TITLE
bump version to 0.30.3

### DIFF
--- a/hhfab
+++ b/hhfab
@@ -96,8 +96,8 @@ findLatestVersion() {
 
 installFile() {
   case "$VERSION" in
-    latest) VERSION="v0.30.1";;
-    beta-1) VERSION="v0.30.1";;
+    latest) VERSION="v0.30.3";;
+    beta-1) VERSION="v0.30.3";;
     alpha-7) VERSION="v0.19.2";;
   esac
 


### PR DESCRIPTION
this version bump includes the changes to the kernel arguments on the live-media installer and adding the `ConfigureWithoutCarrier` option to the interface configuration file of the switch management interface of the control node